### PR TITLE
upgrade alpine image to 3.14 and 3.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,10 +15,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - context: alpine3.12
+          - context: alpine
+            args: |
+              ALPINE_VERSION=3.14
+            tags: |
+              nightly-alpine3.14
+              nightly-alpine
+          - context: alpine
+            args: |
+              ALPINE_VERSION=3.12
             tags: |
               nightly-alpine3.12
-              nightly-alpine
           - context: bullseye
             tags: |
               nightly-bullseye
@@ -66,6 +73,7 @@ jobs:
       - uses: docker/build-push-action@v2
         with:
           context: ${{ matrix.context }}
+          build-args: ${{ matrix.args }}
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,6 @@ jobs:
               ALPINE_VERSION=3.14
             tags: |
               nightly-alpine3.14
-          - context: alpine
-            args: |
-              ALPINE_VERSION=3.13
-            tags: |
-              nightly-alpine3.13
           - context: bullseye
             tags: |
               nightly-bullseye

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,20 @@ jobs:
         include:
           - context: alpine
             args: |
-              ALPINE_VERSION=3.14
+              ALPINE_VERSION=3.15
             tags: |
-              nightly-alpine3.14
+              nightly-alpine3.15
               nightly-alpine
           - context: alpine
             args: |
-              ALPINE_VERSION=3.12
+              ALPINE_VERSION=3.14
             tags: |
-              nightly-alpine3.12
+              nightly-alpine3.14
+          - context: alpine
+            args: |
+              ALPINE_VERSION=3.13
+            tags: |
+              nightly-alpine3.13
           - context: bullseye
             tags: |
               nightly-bullseye

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.12
+# to specify a different alpine version, use --build-arg ALPINE_VERSION=3.12
+# when building the image
+ARG ALPINE_VERSION=3.14
+FROM alpine:${ALPINE_VERSION}
 
 RUN apk add --no-cache \
         ca-certificates \


### PR DESCRIPTION
The rust non-nightly image is based on alpine 3.14, so this PR proposes to follow the stable image.
This modification also introduce build arguments to be able to build also for 3.13, 3.12 and the coming 3.15, etc images.

Signed-off-by: Jérémie Drouet <jeremie.drouet@gmail.com>